### PR TITLE
🚀 feature: add cluster icon

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Union
+from typing import Type, Union
 
 from graphviz import Digraph
 
@@ -225,7 +226,7 @@ class Cluster:
         self,
         label: str = "cluster",
         direction: str = "LR",
-        icon_node: "Node" = None,
+        icon_node: Union[Type["Node"], str] = None,
         icon_size: int = 24,
         graph_attr: Optional[dict] = None,
     ):
@@ -252,7 +253,18 @@ class Cluster:
 
         # Set icon from given node.
         if self.icon_node:
-            _icon_label = geticonlabel(self.icon_node._load_icon(), self.icon_size, self.label)
+            basedir = Path(os.path.abspath(os.path.dirname(__file__)))
+            _icon_node = self.icon_node
+            _icon_path = None
+
+            if isinstance(_icon_node, str):
+                _icon_path = os.path.join(basedir.parent, _icon_node)
+            elif _icon_node._icon_dir:
+                _icon_path = os.path.join(basedir.parent, _icon_node._icon_dir, _icon_node._icon)
+            else:
+                _icon_path = os.path.join(basedir.parent, _icon_node._icon)
+
+            _icon_label = geticonlabel(_icon_path, self.icon_size, self.label)
 
             self.dot.graph_attr["label"] = _icon_label
         else:

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -37,6 +37,10 @@ def setcluster(cluster: "Cluster"):
     __cluster.set(cluster)
 
 
+def geticonlabel(path: str = "", size: int = 24, label: str = ""):
+    return f'<<table border="0" width="100%"><tr><td fixedsize="true" width="{size}" height="{size}"><img src="{path}" /></td><td>{label}</td></tr></table>>'
+
+
 class Diagram:
     __directions = ("TB", "BT", "LR", "RL")
     __curvestyles = ("ortho", "curved")
@@ -221,25 +225,38 @@ class Cluster:
         self,
         label: str = "cluster",
         direction: str = "LR",
+        icon_node: "Node" = None,
+        icon_size: int = 24,
         graph_attr: Optional[dict] = None,
     ):
         """Cluster represents a cluster context.
 
         :param label: Cluster label.
         :param direction: Data flow direction. Default is 'left to right'.
+        :param icon: Icon of the cluster in top-left corner.
+        :param icon_size: Icon size.
         :param graph_attr: Provide graph_attr dot config attributes.
         """
         if graph_attr is None:
             graph_attr = {}
         self.label = label
         self.name = "cluster_" + self.label
+        self.icon_node = icon_node
+        self.icon_size = icon_size
 
         self.dot = Digraph(self.name)
 
         # Set attributes.
         for k, v in self._default_graph_attrs.items():
             self.dot.graph_attr[k] = v
-        self.dot.graph_attr["label"] = self.label
+
+        # Set icon from given node.
+        if self.icon_node:
+            _icon_label = geticonlabel(self.icon_node._load_icon(), self.icon_size, self.label)
+
+            self.dot.graph_attr["label"] = _icon_label
+        else:
+            self.dot.graph_attr["label"] = self.label
 
         if not self._validate_direction(direction):
             raise ValueError(f'"{direction}" is not a valid direction')

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -5,6 +5,7 @@ import pathlib
 
 from diagrams import Cluster, Diagram, Edge, Node
 from diagrams import getcluster, getdiagram, setcluster, setdiagram
+from diagrams.custom import Custom
 
 
 class DiagramTest(unittest.TestCase):
@@ -103,20 +104,19 @@ class DiagramTest(unittest.TestCase):
 
     def test_empty_name(self):
         """Check that providing an empty name don't crash, but save in a diagrams_image.xxx file."""
-        self.name = 'diagrams_image'
+        self.name = "diagrams_image"
         with Diagram(show=False):
             Node("node1")
         self.assertTrue(os.path.exists(f"{self.name}.png"))
-    
+
     def test_autolabel(self):
         with Diagram(name=os.path.join(self.name, "nodes_to_node"), show=False):
             node1 = Node("node1")
-            self.assertTrue(node1.label,"Node\nnode1")
-
+            self.assertTrue(node1.label, "Node\nnode1")
 
     def test_outformat_list(self):
         """Check that outformat render all the files from the list."""
-        self.name = 'diagrams_image'
+        self.name = "diagrams_image"
         with Diagram(show=False, outformat=["dot", "png"]):
             Node("node1")
         # both files must exist
@@ -168,6 +168,13 @@ class ClusterTest(unittest.TestCase):
                     self.assertEqual(c2, getcluster())
                 self.assertEqual(c1, getcluster())
             self.assertIsNone(getcluster())
+
+    def test_with_node_icon(self):
+        with Diagram(name=os.path.join(self.name, "with_node_icon"), show=False):
+            node = Custom("Public Domain Dedication", "resources/aws/network/vpc.png")
+            with Cluster(icon_node=node) as cluster:
+                self.assertIsNotNone(cluster)
+                self.assertTrue('<img src="resources/aws/network/vpc.png" />' in cluster.dot.graph_attr["label"])
 
     def test_node_not_in_diagram(self):
         # Node must be belong to a diagrams.
@@ -311,7 +318,6 @@ class ResourcesTest(unittest.TestCase):
         i.e. resources/<provider>/<type>/<image>, so check that this depth isn't
         exceeded.
         """
-        resources_dir = pathlib.Path(__file__).parent.parent / 'resources'
-        max_depth = max(os.path.relpath(d, resources_dir).count(os.sep) + 1
-                        for d, _, _ in os.walk(resources_dir))
+        resources_dir = pathlib.Path(__file__).parent.parent / "resources"
+        max_depth = max(os.path.relpath(d, resources_dir).count(os.sep) + 1 for d, _, _ in os.walk(resources_dir))
         self.assertLessEqual(max_depth, 2)

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -174,7 +174,7 @@ class ClusterTest(unittest.TestCase):
             node = Custom("Public Domain Dedication", "resources/aws/network/vpc.png")
             with Cluster(icon_node=node) as cluster:
                 self.assertIsNotNone(cluster)
-                self.assertTrue('<img src="resources/aws/network/vpc.png" />' in cluster.dot.graph_attr["label"])
+                self.assertTrue("resources/aws/network/vpc.png" in cluster.dot.graph_attr["label"])
 
     def test_node_not_in_diagram(self):
         # Node must be belong to a diagrams.


### PR DESCRIPTION
Add the icon as part of label in cluster, to visualize the 'VPC' type resources.

Origin PR: <https://github.com/mingrammer/diagrams/pull/853>
Others: 
- <https://github.com/mingrammer/diagrams/pull/439>
- <https://github.com/mingrammer/diagrams/pull/438>

Demo:
```
with Diagram("demo", show=False):
    with Cluster("vpc", icon_node=VPC):
        igw = InternetGateway()
        
        with Cluster("public", icon_node=PublicSubnet):
            nat = NATGateway()
            elb = ElasticLoadBalancing()
        with Cluster("private", icon_node=PrivateSubnet):
            eks = EKS()
        with Cluster("intra", icon_node=PrivateSubnet):
            rds = RDSInstance()

        igw >> elb >> eks >> rds
        eks >> nat >> igw
```

![demo](https://github.com/Anddd7/diagrams-ext/assets/24785373/ea83eb65-db88-4df2-be40-9dfb0528d4e4)

